### PR TITLE
Set timeouts on build and activation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,10 +5,6 @@ on:
 
   pull_request:
 
-  push:
-    branches-ignore:
-    - master
-
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,12 +5,20 @@ on:
 
   pull_request:
 
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
 
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref || github.ref }}
 
     - uses: cachix/install-nix-action@v18
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,11 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+
+    env:
+      CACHIX_ACTIVATE_TOKEN: ${{ secrets.CACHIX_ACTIVATE_TOKEN }}
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
     steps:
 
     - uses: actions/checkout@v3
@@ -28,11 +33,20 @@ jobs:
       with:
         name: akirak
 
-    - name: Build and deploy
+    - name: Build the deploys
+      id: build
       run: |
         spec=$(nix build .#cachix-deploys --print-out-paths)
-        cachix push akirak $spec
-        cachix deploy activate $spec
+        echo "spec_path=$spec" >> $GITHUB_OUTPUT
+
+    - name: Push to Cachix
+      run: |
+        cachix push akirak $DEPLOY_SPEC
       env:
-        CACHIX_ACTIVATE_TOKEN: ${{ secrets.CACHIX_ACTIVATE_TOKEN }}
-        CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        DEPLOY_SPEC: ${{ steps.build.outputs.spec_path }}
+
+    - name: Deploy
+      run: |
+        cachix deploy activate $DEPLOY_SPEC
+      env:
+        DEPLOY_SPEC: ${{ steps.build.outputs.spec_path }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@ on:
     - 'suites/**'
 
 jobs:
+  check:
+    uses: ./.github/workflows/check.yml
+    with:
+      ref: ${{ github.ref_name }}
+
   build-and-deploy:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
 
     - name: Build the deploys
       id: build
+      # A timeout set arbitrary
+      timeout-minutes: 20
       run: |
         spec=$(nix build .#cachix-deploys --print-out-paths)
         echo "spec_path=$spec" >> $GITHUB_OUTPUT
@@ -51,6 +53,9 @@ jobs:
         DEPLOY_SPEC: ${{ steps.build.outputs.spec_path }}
 
     - name: Deploy
+      # Should be deployed instantly. Some machines may be offline, but then you
+      # can rerun this workflow
+      timeout-minutes: 1
       run: |
         cachix deploy activate $DEPLOY_SPEC
       env:


### PR DESCRIPTION
`cachix deploy activate` is a synchronous task, so it awaits for an agent infinitely if one of the deployment targets is offline. To save usage of GitHub Actions, I have set a timeout.