### PR TITLE
Add hardware support to make it work in non-installation ISO

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,7 +118,7 @@
         };
 
         nixosModules = {
-          asus-br1100 = import ./modules/models/asus-br1100.nix {
+          asus-br1100 = import ./modules/models/asus-br1100 {
             inherit (inputs) nixos-hardware;
           };
         };

--- a/modules/models/asus-br1100/acpi_call.nix
+++ b/modules/models/asus-br1100/acpi_call.nix
@@ -1,0 +1,6 @@
+{config, ...}: {
+  boot.kernelModules = ["acpi_call"];
+  boot.extraModulePackages = with config.boot.kernelPackages; [
+    acpi_call
+  ];
+}

--- a/modules/models/asus-br1100/default.nix
+++ b/modules/models/asus-br1100/default.nix
@@ -1,12 +1,10 @@
-{nixos-hardware}: {
-  config,
-  pkgs,
-  ...
-}: {
+{nixos-hardware}: {pkgs, ...}: {
   imports = [
     (nixos-hardware.outPath + "/common/pc/laptop")
     (nixos-hardware.outPath + "/common/gpu/intel.nix")
     ./r8168.nix
+    ./wireless.nix
+    ./acpi_call.nix
   ];
 
   # I don't know if this parameter is necessary.

--- a/modules/models/asus-br1100/default.nix
+++ b/modules/models/asus-br1100/default.nix
@@ -1,0 +1,16 @@
+{nixos-hardware}: {
+  config,
+  pkgs,
+  ...
+}: {
+  imports = [
+    (nixos-hardware.outPath + "/common/pc/laptop")
+    (nixos-hardware.outPath + "/common/gpu/intel.nix")
+    ./r8168.nix
+  ];
+
+  # I don't know if this parameter is necessary.
+  boot.kernelParams = ["nouveau.modeset=0"];
+
+  boot.kernelPackages = pkgs.linuxKernel.packages.linux_6_0;
+}

--- a/modules/models/asus-br1100/r8168.nix
+++ b/modules/models/asus-br1100/r8168.nix
@@ -1,18 +1,8 @@
-{nixos-hardware}: {
-  config,
+{
   pkgs,
+  config,
   ...
 }: {
-  imports = [
-    (nixos-hardware.outPath + "/common/pc/laptop")
-    (nixos-hardware.outPath + "/common/gpu/intel.nix")
-  ];
-
-  # I don't know if this parameter is necessary.
-  boot.kernelParams = ["nouveau.modeset=0"];
-
-  boot.kernelPackages = pkgs.linuxKernel.packages.linux_6_0;
-
   # At present, wired interface does not work even with this kernel module due
   # to a common "ucsi_acpi usbc000:00: ppm init failed" error. This issue may be
   # fixed at some point, but I am not sure.

--- a/modules/models/asus-br1100/wireless.nix
+++ b/modules/models/asus-br1100/wireless.nix
@@ -1,0 +1,5 @@
+{pkgs, ...}: {
+  boot.kernelModules = ["iwlwifi"];
+  hardware.firmware = [pkgs.wireless-regdb];
+  hardware.enableRedistributableFirmware = true;
+}


### PR DESCRIPTION
The installation ISO loads various modules out of the box, but its unsuitable for daily work due to lack of customizability. With this PR, at least networking (both wired and wireless) works on the laptop.