### PR TITLE
Reduce CI frequency and prevent pushing of sources

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ on:
     - 'suites/**'
     - 'hm/**'
 
+  schedule:
+    - cron: '0 18 * * *' # 3:00 am JST
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,6 @@ on:
     - 'suites/**'
     - 'hm/**'
 
-  repository_dispatch:
-    types:
-    - deploy
-
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,7 @@ jobs:
       with:
         name: akirak
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        pushFilter: '-source$'
 
     # - run: |
     #     nix flake check \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Build the deploys
       id: build
       # A timeout set arbitrary
-      timeout-minutes: 30
+      timeout-minutes: 90
       run: |
         spec=$(nix build .#cachix-deploys --print-out-paths \
                --override-input emacs-config github:akirak/emacs-config/develop \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,9 @@ on:
   schedule:
     - cron: '0 18 * * *' # 3:00 am JST
 
+env:
+  dry: ${{ github.event.event_name == 'push' }}
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -54,17 +57,20 @@ jobs:
       timeout-minutes: 90
       run: |
         spec=$(nix build .#cachix-deploys --print-out-paths \
+               ${{ env.dry == 'true' ? '--dry-run' : '' }} \
                --override-input emacs-config github:akirak/emacs-config/develop \
                --override-input emacs-config/flake-pins github:akirak/flake-pins)
         echo "spec_path=$spec" >> $GITHUB_OUTPUT
 
     - name: Push to Cachix
+      if: ${{ env.dry == 'false' }}
       run: |
         cachix push akirak $DEPLOY_SPEC
       env:
         DEPLOY_SPEC: ${{ steps.build.outputs.spec_path }}
 
     - name: Deploy
+      if: ${{ env.dry == 'false' }}
       # Should be deployed instantly. Some machines may be offline, but then you
       # can rerun this workflow
       timeout-minutes: 1


### PR DESCRIPTION
Instead of rebuilding whole configurations every time a new commit is pushed to master, rebuild and deploy them periodically.