### PR TITLE
Improve the agenix integration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,10 @@
           };
         };
 
-      hostPubkeys = import ./secrets/host-pubkeys.nix;
+      hostPubkeys = lib.pipe (lib.importTOML ./machines/metadata.toml).hosts [
+        (lib.filterAttrs (_: attrs: attrs ? publicKey))
+        (builtins.mapAttrs (_: attrs: attrs.publicKey))
+      ];
     in
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [

--- a/flake.nix
+++ b/flake.nix
@@ -124,6 +124,7 @@
           };
         };
 
+      hostPubkeys = import ./secrets/host-pubkeys.nix;
     in
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [
@@ -375,7 +376,7 @@
 
         agenix-rekey = inputs.agenix-rekey.configure {
           userFlake = self;
-          nodes = self.nixosConfigurations;
+          nodes = builtins.intersectAttrs hostPubkeys self.nixosConfigurations;
         };
 
         templates = {
@@ -409,7 +410,7 @@
                 if self' ? rev then builtins.substring 0 7 self'.rev else "dirty"
               }";
 
-              hostPubkey = (import ./secrets/host-pubkeys.nix).${hostName} or null;
+              hostPubkey = hostPubkeys.${hostName} or null;
             in
             channel.lib.nixosSystem {
               inherit system specialArgs;

--- a/machines/metadata.toml
+++ b/machines/metadata.toml
@@ -1,0 +1,15 @@
+# Use `ssh-keyscan -t ed25519 <hostname>...` to get the public key(s) remotely
+[hosts.zheng]
+ipAddress = "192.168.10.1"
+publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPok1B5NsawQoyxJ2Is3wynnfqZ51o1fyueJ3gpLLCa5"
+
+[hosts.li]
+ipAddress = "192.168.10.60"
+publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPFhr1lIqPjRnzlfh5nfM8+CQj2BgC6fUk6HE/tYHRnb"
+
+[hosts.yang]
+ipAddress = "192.168.10.186"
+publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBBqIBetzQSQhJeOgBXCcNwwyWToSGh2ZUMLEROwwxeF"
+
+[networks.home]
+subnet = "192.168.10.0/16"

--- a/secrets/host-pubkeys.nix
+++ b/secrets/host-pubkeys.nix
@@ -1,6 +1,0 @@
-{
-  # Use `ssh-keyscan -t ed25519 <hostname>...` to get the public key(s) remotely
-  li = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPFhr1lIqPjRnzlfh5nfM8+CQj2BgC6fUk6HE/tYHRnb";
-  yang = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBBqIBetzQSQhJeOgBXCcNwwyWToSGh2ZUMLEROwwxeF";
-  zheng = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPok1B5NsawQoyxJ2Is3wynnfqZ51o1fyueJ3gpLLCa5";
-}


### PR DESCRIPTION
Follow up #143. All `nodes` in the agenix-rekey configuration, i.e. `agenix-rekey.configure`, should have agenix properly configured. Otherwise, some of the `agenix` (from agenix-rekey) subcommands do not work. 