### PR TITLE
Fix up the file system setup for ollama

### DIFF
--- a/machines/li/default.nix
+++ b/machines/li/default.nix
@@ -116,7 +116,7 @@ in
   services.ollama = {
     enable = true;
     acceleration = false;
-    # Also see ./rpool5 for impermanence setup for /var/lib/private
+    # /var/lib/private is on a separate file system
   };
 
   home-manager.users.${homeUser} = {

--- a/machines/li/rpool5/default.nix
+++ b/machines/li/rpool5/default.nix
@@ -24,18 +24,6 @@
       "/etc/NetworkManager/system-connections"
       "/var/lib/bitwarden_rs"
       "/var/backup/vaultwarden"
-
-      # /var/lib/private is required by ollama, and it will contain
-      # /var/lib/private/scrutiny.
-      #
-      # Also note that /var/lib/private/ollama should be a separate file system,
-      # as it will contain LLM models.
-      {
-        directory = "/var/lib/private";
-        user = "root";
-        group = "root";
-        mode = "700";
-      }
     ];
   };
 }

--- a/machines/li/rpool5/extras.nix
+++ b/machines/li/rpool5/extras.nix
@@ -27,9 +27,10 @@
     compression = "none";
   };
 
-  fileSystems."/var/lib/private/ollama" = {
+  fileSystems."/var/lib/private" = {
     device = "rpool5/local/ollama";
     fsType = "zfs";
+    # The root directory of this file system needs to have 0700 permission.
   };
 
   fileSystems."/media/virtualbox" = {


### PR DESCRIPTION
It turns out that #166 does not work as expected. Symlinking with impermanence is done after mounting filesystems. To store ollama models on a separate file system, it should have been done this way.