### PR TITLE
Fix the Intel ARC GPU configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,16 @@
               });
             }
           );
+          intel-media-driver = prev.intel-media-driver.overrideAttrs {
+            version = "24.4.4";
+            # Use the master newer than 24.4.4 for bugfixes.
+            src = prev.fetchFromGitHub {
+              owner = "intel";
+              repo = "media-driver";
+              rev = "76b1eae796e8d1a697ac63a54f04c8d866c8b348";
+              hash = "sha256-4BikrE/u5sVUIDcF9+8scbcAbzSFoH9HmbH5bRuPn+4=";
+            };
+          };
         })
       ];
 

--- a/profiles/intel-arc/default.nix
+++ b/profiles/intel-arc/default.nix
@@ -11,12 +11,22 @@
       intel-ocl
       # nixos-unstable
       vpl-gpu-rt
+      intel-media-sdk
       intel-compute-runtime
       intel-vaapi-driver
     ];
   };
 
-  environment.sessionVariables.LIBVA_DRIVER_NAME = "iHD";
+  boot.kernelParams = [
+    # Check the ID by running `lspci -k | grep -EA3 'VGA|3D|Display'`
+    "i915.force_probe=6021"
+    "i915.enable_guc=3"
+  ];
+
+  environment.sessionVariables = {
+    VDPAU_DRIVER = "va_gl";
+    LIBVA_DRIVER_NAME = "iHD";
+  };
   hardware.intelgpu.driver = "xe";
 
   # Use the latest kernel for the intel driver that supports ZFS


### PR DESCRIPTION
With these changes, ffmpeg can successfully perform AV1 encoding using the hardware codec via QuickSync (QSV).